### PR TITLE
get_object_schema ordinal (non list) type support

### DIFF
--- a/rest_framework_smoke/tests/schemas.py
+++ b/rest_framework_smoke/tests/schemas.py
@@ -40,8 +40,12 @@ def get_object_schema(schema: dict) -> dict:
         if "type" not in attribute:
             # don't know what it is
             continue
-        # remove null because of high probability of type check skip
-        attribute["type"] = [t for t in attribute["type"] if t != "null"]
+        if isinstance(attribute["type"], str):
+            attribute["type"] = [attribute["type"]]
+        elif isinstance(attribute["type"], (list, tuple)):
+            # remove null because of high probability of type check skip
+            attribute["type"] = [t for t in attribute["type"] if t != "null"]
+
         if attribute["type"] == ["object"]:
             # ensure that object schema is enforced
             schema[name] = get_object_schema(attribute["properties"])

--- a/testproject/testapp/schemas.py
+++ b/testproject/testapp/schemas.py
@@ -1,5 +1,5 @@
 TASK_SCHEMA = {
-    "id": {"type": ["number"]},
+    "id": {"type": "number"},
     "name": {"type": ["string", "null"]},
 }
 
@@ -7,7 +7,7 @@ PROJECT_SCHEMA = {
     "id": {"type": ["number"]},
     "name": {"type": ["string"]},
     "task_set": {
-        "type": ["array"],
+        "type": "array",
         "items": TASK_SCHEMA,
     }
 }


### PR DESCRIPTION
According to In [json schema specification](https://json-schema.org/understanding-json-schema/reference/type.html), `type` key can contain literal string type representation or array of types. Since string type is iterable, function {{get_object_schema}} unpack so string in tuples that malforms schema.
This PR fixes this issue and accepts string type literals.