### PR TITLE
get_list_schema allow nulls in pagination schema

### DIFF
--- a/rest_framework_smoke/tests/mixins.py
+++ b/rest_framework_smoke/tests/mixins.py
@@ -153,7 +153,7 @@ class APIHelpersMixin(MixinTarget):
 
         schema = self.pagination_schema
         schema.update({"results": result_list_schema})
-        return schemas.get_object_schema(schema)
+        return schema
 
     def assert_json_schema(self, obj: dict, schema: dict) -> None:
         """ Checks response schema."""

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -120,3 +120,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 10,
+}

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -8,7 +8,6 @@ class ProjectViewSetTestCase(ReadOnlyViewSetTestsMixin, APITestCase):
     object_name = 'project'
     basename = 'projects'
     schema = details_schema = schemas.PROJECT_SCHEMA
-    pagination_schema = None
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Method `APIHelpersMixin.get_list_schema` performs exclusions for types in pagination_schema.
Since default PAGINATION_SCHEMA variable has nulls allowed in `next` and `previous` keys, to pass tests it is necessary to perform request with page from the middle of large queryset, depending of page size specified in rest framework settings.
Seems reasonable to pass pagination_schema as is when getting list schema.